### PR TITLE
移除 JCode iframe 的滚动条

### DIFF
--- a/src/components/JCode/index.js
+++ b/src/components/JCode/index.js
@@ -12,7 +12,7 @@ export const JCode = (props, ref) => {
 
   return (
     <iframe src={source}
-      scrolling="yes"
+      scrolling="no"
       style={iframeStyle}
       title="jcode"
     ></iframe>


### PR DESCRIPTION
 code.juejin.cn 里面 `section .arco-layout .embed__embedLayout` 的 `min-height:430px` 导致内容比外部 iframe 设置的 420px 高度更高，产生滚动条，滚动页面时如果光标经过 iframe 会产生抖动（safari 和 chrome 均复现）

移除前：
<img width="855" alt="image" src="https://user-images.githubusercontent.com/5164225/173287809-7769120f-53e7-4c42-a39c-e0611642f100.png">

移除后：
<img width="851" alt="image" src="https://user-images.githubusercontent.com/5164225/173287908-f05422dc-aa45-4f7c-9d21-31ff1b9d6d1c.png">

